### PR TITLE
Correction for RG350 default

### DIFF
--- a/S91alsaSettings
+++ b/S91alsaSettings
@@ -191,7 +191,7 @@ state.GCW0 {
 EOM
 		fi
 		# Use the file to restore defaults
-		/usr/sbin/alsactl -f $ALSACTL_DEFAULT_STATEFILE restore
+		/usr/sbin/alsactl -f $ALSACTL_RG350_DEFAULT_STATEFILE restore
 		;;
 		
         *)


### PR DESCRIPTION
Does this correction need to be made?  Otherwise it appears you're creating a specific statefile but then not actually using it?