### PR TITLE
change to allow default restore without ssh

### DIFF
--- a/S91alsaSettings
+++ b/S91alsaSettings
@@ -6,12 +6,27 @@
 ALSACTL_STATEFILE=/usr/local/etc/asound.state
 ALSACTL_DEFAULT_STATEFILE=/usr/local/etc/asound-defaults.state
 ALSACTL_RG350_DEFAULT_STATEFILE=/usr/local/etc/asound-RG350M-defaults.state
+ALSACTL_SDCARD_CONFIF=/media/sdcard/alsactl
+
+if [ ! -d ${ALSACTL_SDCARD_CONFIF} ];
+	mkdir -p "${ALSACTL_SDCARD_CONFIF}"
+fi
+if [ ! -f ${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt ];
+	echo "" > "${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt"
+fi
 
 case "$1" in
         start)  
 		# This is run on system boot:
-		# Check for a personalized state file
-                if [ -f $ALSACTL_STATEFILE ]; then
+		# Check for a personalized state file with SDCARD confif
+		if [ -f $ALSACTL_STATEFILE ] && [ -f ${ALSACTL_SDCARD_CONFIF}/DEFAULT ]; then
+			mv ${ALSACTL_SDCARD_CONFIF}/DEFAULT ${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt
+			# Load the device default that we saved the first time this was run
+			# These settings should match the OS defaults for your device
+			/usr/sbin/alsactl -f $ALSACTL_DEFAULT_STATEFILE restore
+		fi
+		# Check for a personalized state file without SDCARD config
+                if [ -f $ALSACTL_STATEFILE ] && [ ! -f "${ALSACTL_SDCARD_CONFIF}/DEFAULT" ]; then
 			echo "Loading Alsamixer config..."
 			# Load it!
 			/usr/sbin/alsactl -f $ALSACTL_STATEFILE restore

--- a/S91alsaSettings
+++ b/S91alsaSettings
@@ -8,13 +8,15 @@ ALSACTL_DEFAULT_STATEFILE=/usr/local/etc/asound-defaults.state
 ALSACTL_RG350_DEFAULT_STATEFILE=/usr/local/etc/asound-RG350M-defaults.state
 ALSACTL_SDCARD_CONFIF=/media/sdcard/alsactl
 
-if [ ! -d ${ALSACTL_SDCARD_CONFIF} ];
+if mount|grep -q /media/sdcard
+then
+  if [ ! -d ${ALSACTL_SDCARD_CONFIF} ];
 	mkdir -p "${ALSACTL_SDCARD_CONFIF}"
-fi
-if [ ! -f ${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt ];
+  fi
+  if [ ! -f ${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt ];
 	echo "" > "${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt"
+  fi
 fi
-
 case "$1" in
         start)  
 		# This is run on system boot:

--- a/S91alsaSettings
+++ b/S91alsaSettings
@@ -24,9 +24,8 @@ case "$1" in
 			# Load the device default that we saved the first time this was run
 			# These settings should match the OS defaults for your device
 			/usr/sbin/alsactl -f $ALSACTL_DEFAULT_STATEFILE restore
-		fi
 		# Check for a personalized state file without SDCARD config
-                if [ -f $ALSACTL_STATEFILE ] && [ ! -f "${ALSACTL_SDCARD_CONFIF}/DEFAULT" ]; then
+                elif [ -f $ALSACTL_STATEFILE ] && [ ! -f "${ALSACTL_SDCARD_CONFIF}/DEFAULT" ]; then
 			echo "Loading Alsamixer config..."
 			# Load it!
 			/usr/sbin/alsactl -f $ALSACTL_STATEFILE restore

--- a/S91alsaSettings
+++ b/S91alsaSettings
@@ -6,28 +6,28 @@
 ALSACTL_STATEFILE=/usr/local/etc/asound.state
 ALSACTL_DEFAULT_STATEFILE=/usr/local/etc/asound-defaults.state
 ALSACTL_RG350_DEFAULT_STATEFILE=/usr/local/etc/asound-RG350M-defaults.state
-ALSACTL_SDCARD_CONFIF=/media/sdcard/alsactl
+ALSACTL_SDCARD_CONFIG=/media/sdcard/alsactl
 
 if mount|grep -q /media/sdcard
 then
-  if [ ! -d ${ALSACTL_SDCARD_CONFIF} ];
-	mkdir -p "${ALSACTL_SDCARD_CONFIF}"
+  if [ ! -d ${ALSACTL_SDCARD_CONFIG} ];
+	mkdir -p "${ALSACTL_SDCARD_CONFIG}"
   fi
-  if [ ! -f ${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt ];
-	echo "" > "${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt"
+  if [ ! -f ${ALSACTL_SDCARD_CONFIG}/DEFAULT.txt ];
+	echo "" > "${ALSACTL_SDCARD_CONFIG}/DEFAULT.txt"
   fi
 fi
 case "$1" in
         start)  
 		# This is run on system boot:
-		# Check for a personalized state file with SDCARD confif
-		if [ -f $ALSACTL_STATEFILE ] && [ -f ${ALSACTL_SDCARD_CONFIF}/DEFAULT ]; then
-			mv ${ALSACTL_SDCARD_CONFIF}/DEFAULT ${ALSACTL_SDCARD_CONFIF}/DEFAULT.txt
+		# Check for a personalized state file with SDCARD config
+		if [ -f $ALSACTL_STATEFILE ] && [ -f ${ALSACTL_SDCARD_CONFIG}/DEFAULT ]; then
+			mv ${ALSACTL_SDCARD_CONFIG}/DEFAULT ${ALSACTL_SDCARD_CONFIG}/DEFAULT.txt
 			# Load the device default that we saved the first time this was run
 			# These settings should match the OS defaults for your device
 			/usr/sbin/alsactl -f $ALSACTL_DEFAULT_STATEFILE restore
 		# Check for a personalized state file without SDCARD config
-                elif [ -f $ALSACTL_STATEFILE ] && [ ! -f "${ALSACTL_SDCARD_CONFIF}/DEFAULT" ]; then
+                elif [ -f $ALSACTL_STATEFILE ] && [ ! -f "${ALSACTL_SDCARD_CONFIG}/DEFAULT" ]; then
 			echo "Loading Alsamixer config..."
 			# Load it!
 			/usr/sbin/alsactl -f $ALSACTL_STATEFILE restore


### PR DESCRIPTION
Do you think this would work?  
Would hopefully restore defaults by simply renaming:
"/media/sdcard/alsactl/DEFAULT.txt" to "/media/sdcard/alsactl/DEFAULT"
Which could easily be done just from commander on the device.